### PR TITLE
Fix: specify read only fields and update data generator to generate bell-shaped offers for two books

### DIFF
--- a/generateData.py
+++ b/generateData.py
@@ -6,7 +6,7 @@ from faker import Faker
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'buecherboerse.settings')
 django.setup()
 
-from search.models import Seller, Book, Offer, Exam  # Update 'your_app' to the name of your Django app
+from search.models import Seller, Book, Offer, Exam
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
@@ -57,6 +57,66 @@ def create_offers(n, books, sellers):
                              member=User.objects.first())
 
 
+def create_specific_book_offers(n, isbn, min_price, max_price):
+    """Create n offers for a specific book with Gaussian price distribution"""
+    # Create or get the specific exam for the book
+    exam, created = Exam.objects.get_or_create(name="Zivilverfahrensrecht und so weiter")
+    if created:
+        print(f"Created exam: {exam.name}")
+    
+    # Create or get the specific book
+    book, created = Book.objects.get_or_create(
+        isbn=isbn,
+        defaults={
+            'title': "Österreichisches Strafrecht. Besonderer Teil II (§§ 169 bis 321k StGB)",
+            'authors': "Maxima Musterfrau, Max Mustermann, Herr von und zu Name",
+            'maxPrice': 123.41,
+            'edition': 123,
+            'publisher': "FVJus Verlag bester Verlag",
+            'exam': exam
+        }
+    )
+    if created:
+        print(f"Created book: {book.title}")
+    
+    # Create or get the specific seller
+    seller, created = Seller.objects.get_or_create(
+        matriculationNumber="01234567",
+        defaults={
+            'fullName': "Martha Musterfrau",
+            'email': "user@email.com"
+        }
+    )
+    if created:
+        print(f"Created seller: {seller.fullName}")
+    
+    # Calculate mean and std for Gaussian distribution
+    mean_price = (min_price + max_price) / 2
+    std_price = (max_price - min_price) / 6  # 99.7% of values within range
+    
+    for _ in range(n):
+        # Generate Gaussian price, clamped to min/max bounds
+        price = random.gauss(mean_price, std_price)
+        price = max(min_price, min(max_price, price))  # Clamp to bounds
+        price = round(price, 2)
+        
+        active = fake.boolean()
+        location = fake.postcode()[:4]
+        marked = fake.boolean()
+        
+        Offer.objects.create(
+            book=book, 
+            price=price, 
+            seller=seller,  # Use the specific seller
+            marked=marked, 
+            active=active, 
+            location=location,
+            member=User.objects.first()
+        )
+    
+    print(f"Created {n} offers for book '{book.title}' (ISBN: {isbn}) by seller {seller.fullName}")
+
+
 def generate_data(books=10, sellers=5, offers=20):
     exams = create_exams(5)  # Create some exams for the books
     create_sellers(sellers)
@@ -69,4 +129,9 @@ def generate_data(books=10, sellers=5, offers=20):
 if __name__ == "__main__":
     # Set the number of Books, Offers, and Sellers you want to create
     generate_data(books=50, sellers=1000, offers=2000)
+    
+    # Create 100 offers for the specific book with Gaussian price distribution
+    create_specific_book_offers(200, "1234123412341", 65, 123)
+    create_specific_book_offers(200, "1231231231231", 45, 76)
+    
     print("Fake data generation completed.")

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -100,16 +100,24 @@ class OfferSerializer(serializers.ModelSerializer):
         queryset=Seller.objects.all(),
         source='seller'
     )
-    member = UserSerializer(read_only=True)
-    member_id = serializers.PrimaryKeyRelatedField(
-        write_only=True,
-        queryset=User.objects.all(),
-        source='member'
-    )
 
     class Meta:
         model = Offer
-        fields = '__all__'
+        fields = ['id', 'book', 'book_id', 'seller', 'seller_id', 'member',
+                 'price', 'marked', 'active', 'createdAt', 'modified', 'location', 'note']
+        extra_kwargs = {
+            'id': {'read_only': True},
+            'member': {'read_only': True},
+            'active': {'read_only': True},
+            'createdAt': {'read_only': True},
+            'modified': {'read_only': True},
+        }
+
+    def create(self, validated_data):
+        request = self.context.get('request')
+        if request and hasattr(request, 'user') and request.user.is_authenticated:
+            validated_data['member'] = request.user
+        return super().create(validated_data)
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)

--- a/search/views.py
+++ b/search/views.py
@@ -310,7 +310,7 @@ class OfferBulkCreationView(APIView):
         if isinstance(data, list) and not data:
             return Response({"error": "Empty list is not allowed"}, status=status.HTTP_400_BAD_REQUEST)
 
-        serializers = [OfferSerializer(data=offer_data) for offer_data in data]
+        serializers = [OfferSerializer(data=offer_data, context={'request': request}) for offer_data in data]
 
         valid_serializers = []
         for serializer in serializers:


### PR DESCRIPTION
Fix: specify read only fields and update data generator to generate bell-shaped offers for two books with the isbn:
* `1234123412341`
* `1231231231231`
and the seller with the matriculation number `01234567`.